### PR TITLE
Chore: Standardize pyproject.toml for Poetry Compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = ">=3.12,<4.0"
 # Core runtime dependencies
 langgraph = ">=0.0.15"
 langchain-core = ">=0.1.0"
-kurrentdbclient = "^0.4.0"
+kurrentdbclient = "^1.0b4"
 pandas = ">=2.0.0"
 matplotlib = ">=3.0.0"
 langgraph-checkpoint = "^2.0.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,45 +1,29 @@
-[project]
+[tool.poetry]
 name = "langgraph_checkpoint_kurrentdb"
 version = "0.1.0"
 description = "KurrentDB checkpoint implementation for LangGraph"
-authors = [
-    {name = "Lougarou",email = "yogisawesome@gmail.com"}
-]
+authors = ["Lougarou <yogisawesome@gmail.com>"]
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
-dependencies = [
-    "langgraph>=0.0.15",
-    "langchain-core>=0.1.0",
-    "kurrentdbclient",
-    "pandas>=2.0.0",
-    "matplotlib>=3.0.0",
-    "pytest (>=8.3.5,<9.0.0)",
-    "pytest-cov>=4.1.0",
-    "pytest-asyncio>=0.26.0",
-]
+packages = [{ include = "langgraph_checkpoint_kurrentdb", from = "src" }]
 
-[tool.poetry]
-packages = [{include = "langgraph_checkpoint_kurrentdb", from = "src"}]
+[tool.poetry.dependencies]
+python = ">=3.12,<4.0"
+# Core runtime dependencies
+langgraph = ">=0.0.15"
+langchain-core = ">=0.1.0"
+kurrentdbclient = "^0.4.0"
+pandas = ">=2.0.0"
+matplotlib = ">=3.0.0"
+langgraph-checkpoint = "^2.0.15"
 
-
-[tool.poetry.group.dev.dependencies]
-pytest-asyncio = "^0.26.0"
+[tool.poetry.group.test.dependencies]
+# Test-specific dependencies
+pytest = ">=7.0.0"
+pytest-asyncio = "^0.26.0" # Consolidated version
+docker = "^6.1.0"
+requests = "^2.31.0"
+pytest-cov = ">=4.1.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.poetry.dependencies]
-langgraph-checkpoint = "^2.0.15"
-kurrentdbclient = "^0.4.0"
-docker = "^6.1.0"
-requests = "^2.31.0"
-
-[project.optional-dependencies]
-test = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.23.0",
-    "docker>=6.1.0",
-    "requests>=2.31.0",
-    "pytest-cov>=4.1.0",
-]


### PR DESCRIPTION
**Problem:**
The `pyproject.toml` file mixed `[project]` (PEP 621) and `[tool.poetry]` standards, causing Poetry parsing errors and making standard commands like `poetry install` unreliable.

```
❯ poetry install --extras test

'name'
```

**Solution:**
Refactored `pyproject.toml` to consistently use the `[tool.poetry]` standard:
- Consolidated metadata and dependencies under `[tool.poetry]` sections.
- Removed redundant/conflicting `[project]` sections.

**Outcome:**
https://app.warp.dev/block/xKiVXSr5v5f4xl7f3JEyRK